### PR TITLE
Update metadata.json to support GNOME 50

### DIFF
--- a/src/metadata.json
+++ b/src/metadata.json
@@ -2,7 +2,7 @@
     "name": "Automatic Theme Switcher",
     "description": "Automatically switches between light and dark themes based on sunrise/sunset times for your location.\nSupports multiple trigger options (golden hour, dawn, dusk, etc.), gradual brightness transitions, and syncs with Night Light.\n\nUses ipinfo.io and openstreetmap.org services for location detection.\n\nIf you find any bugs/issues, feel free to create an issue at https://github.com/amritashan/gnome-shell-extension-auto-theme-switcher/issues",
     "uuid": "auto-theme-switcher@amritashan.github.io",
-    "shell-version": ["45", "46", "47", "48", "49"],
+    "shell-version": ["45", "46", "47", "48", "49", "50"],
     "version": 6,
     "url": "https://github.com/amritashan/gnome-shell-extension-auto-theme-switcher",
     "settings-schema": "org.gnome.shell.extensions.auto-theme-switcher",


### PR DESCRIPTION
Adds support for GNOME 50 by declaring it. From my testing on Fedora 44, nothing seems broken: theme switches automatically, settings work and I have toyed with the debug menu without issues.

Closes #11 